### PR TITLE
Add basic HTML validity test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Rodrigue Audio Site
+
+This repository contains a simple static website.
+
+## Running Tests
+
+Install dependencies using `pip` and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/index.html
+++ b/index.html
@@ -184,7 +184,6 @@ footer{padding:32px 18px;text-align:center;font-size:.8rem;color:var(--muted);}
       <img alt="Chat on WhatsApp" src="WhatsAppButtonGreenSmall.svg" style="width:130px; height:auto; vertical-align:middle;" />
     </a>
   </p>
-</a></p>
  <form action="https://formspree.io/f/your-id" method="POST" class="fade-right">
     <input type="text" name="name" placeholder="Your Name" required>
     <input type="email" name="email" placeholder="Email" required>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+pytest

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import re
+from bs4 import BeautifulSoup
+
+HTML_FILE = Path(__file__).resolve().parents[1] / "index.html"
+
+
+def test_html_parse():
+    content = HTML_FILE.read_text(encoding="utf-8")
+    soup = BeautifulSoup(content, "html.parser")
+    assert soup is not None
+
+
+def test_no_unmatched_tags():
+    content = HTML_FILE.read_text(encoding="utf-8")
+    tags_to_check = ["a", "p", "div", "span"]
+    for tag in tags_to_check:
+        open_tag_pattern = rf"<{tag}(\s|>)"
+        close_tag_pattern = rf"</{tag}>"
+        opens = len(re.findall(open_tag_pattern, content))
+        closes = len(re.findall(close_tag_pattern, content))
+        assert opens == closes, f"Mismatched <{tag}> tags: {opens} open vs {closes} close"


### PR DESCRIPTION
## Summary
- add `pytest` and `beautifulsoup4` requirements
- add instructions on running `pytest`
- add HTML validity test using BeautifulSoup
- fix unmatched closing tag in `index.html`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement beautifulsoup4)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_68800eb6199883259bd6d361b0c10014